### PR TITLE
release: v0.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
-    "@technote-space/github-action-test-helper": "^0.7.22",
+    "@technote-space/github-action-test-helper": "^0.7.24",
     "@testing-library/react-hooks": "^7.0.1",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.6.1",
-    "@types/react": "^17.0.18",
-    "@typescript-eslint/eslint-plugin": "^4.29.1",
-    "@typescript-eslint/parser": "^4.29.1",
+    "@types/node": "^16.7.1",
+    "@types/react": "^17.0.19",
+    "@typescript-eslint/eslint-plugin": "^4.29.2",
+    "@typescript-eslint/parser": "^4.29.2",
     "eslint": "^7.32.0",
     "husky": "^7.0.1",
     "jest": "^27.0.6",
@@ -55,7 +55,7 @@
     "pinst": "^2.1.6",
     "react": "^17.0.2",
     "react-test-renderer": "^17.0.2",
-    "ts-jest": "^27.0.4",
+    "ts-jest": "^27.0.5",
     "typescript": "^4.3.5"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/use-unmount-ref",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "React hook to handle unmount ref.",
   "keywords": [
     "github",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@actions/core@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.4.0.tgz#cf2e6ee317e314b03886adfeb20e448d50d6e524"
-  integrity sha512-CGx2ilGq5i7zSLgiiGUtBCxhRRxibJYU6Fim0Q1Wg2aQL2LTnF27zbqZOrxfvFQ55eSBW0L8uVStgtKMpa0Qlg==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.5.0.tgz#885b864700001a1b9a6fba247833a036e75ad9d3"
+  integrity sha512-eDOLH1Nq9zh+PJlYLqEMkS/jLQxhksPNmUGNBHfa4G+tQmnIhzpctxmchETtVGyBOvXgOVVpYuE40+eS4cUnwQ==
 
 "@actions/github@^5.0.0":
   version "5.0.0"
@@ -811,10 +811,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@technote-space/github-action-test-helper@^0.7.22":
-  version "0.7.22"
-  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.7.22.tgz#49b0b48a8b680f75ad6b6fb94b81613f3565e192"
-  integrity sha512-YRg/s3L6ziLjnsvHm1h68lyKAsq6xK//BhrSBpW0I297acuAS2x3rAXpQvvh90u+tKO8/ZDtwC/EVclt0Gyu0A==
+"@technote-space/github-action-test-helper@^0.7.24":
+  version "0.7.24"
+  resolved "https://registry.yarnpkg.com/@technote-space/github-action-test-helper/-/github-action-test-helper-0.7.24.tgz#e95ad667b2911bcc57f1b0161e6c171fffaa2c1e"
+  integrity sha512-Dhr/zEYu3zweJnxIMTrrrwpSZraJ25C5zNvwI/Iw7jEsn2KZKhoXFJk7Xc2iXIvVYqcwnnkbweAECv6XwdgcWA==
   dependencies:
     "@actions/core" "^1.4.0"
     "@actions/github" "^5.0.0"
@@ -914,10 +914,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@^16.6.1":
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.6.1.tgz#aee62c7b966f55fc66c7b6dfa1d58db2a616da61"
-  integrity sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==
+"@types/node@*", "@types/node@^16.7.1":
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
+  integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -953,10 +953,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.18":
-  version "17.0.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.18.tgz#4109cbbd901be9582e5e39e3d77acd7b66bb7fbe"
-  integrity sha512-YTLgu7oS5zvSqq49X5Iue5oAbVGhgPc5Au29SJC4VeE17V6gASoOxVkUDy9pXFMRFxCWCD9fLeweNFizo3UzOg==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.19":
+  version "17.0.19"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.19.tgz#8f2a85e8180a43b57966b237d26a29481dacc991"
+  integrity sha512-sX1HisdB1/ZESixMTGnMxH9TDe8Sk709734fEQZzCV/4lSu9kJCPbo2PbTRoZM+53Pp0P10hYVyReUueGwUi4A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -984,73 +984,73 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.1.tgz#808d206e2278e809292b5de752a91105da85860b"
-  integrity sha512-AHqIU+SqZZgBEiWOrtN94ldR3ZUABV5dUG94j8Nms9rQnHFc8fvDOue/58K4CFz6r8OtDDc35Pw9NQPWo0Ayrw==
+"@typescript-eslint/eslint-plugin@^4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz#f54dc0a32b8f61c6024ab8755da05363b733838d"
+  integrity sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.29.1"
-    "@typescript-eslint/scope-manager" "4.29.1"
+    "@typescript-eslint/experimental-utils" "4.29.2"
+    "@typescript-eslint/scope-manager" "4.29.2"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz#0af2b17b0296b60c6b207f11062119fa9c5a8994"
-  integrity sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==
+"@typescript-eslint/experimental-utils@4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz#5f67fb5c5757ef2cb3be64817468ba35c9d4e3b7"
+  integrity sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.29.1"
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/typescript-estree" "4.29.1"
+    "@typescript-eslint/scope-manager" "4.29.2"
+    "@typescript-eslint/types" "4.29.2"
+    "@typescript-eslint/typescript-estree" "4.29.2"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.29.1.tgz#17dfbb45c9032ffa0fe15881d20fbc2a4bdeb02d"
-  integrity sha512-3fL5iN20hzX3Q4OkG7QEPFjZV2qsVGiDhEwwh+EkmE/w7oteiOvUNzmpu5eSwGJX/anCryONltJ3WDmAzAoCMg==
+"@typescript-eslint/parser@^4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.29.2.tgz#1c7744f4c27aeb74610c955d3dce9250e95c370a"
+  integrity sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.29.1"
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/typescript-estree" "4.29.1"
+    "@typescript-eslint/scope-manager" "4.29.2"
+    "@typescript-eslint/types" "4.29.2"
+    "@typescript-eslint/typescript-estree" "4.29.2"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz#f25da25bc6512812efa2ce5ebd36619d68e61358"
-  integrity sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==
+"@typescript-eslint/scope-manager@4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz#442b0f029d981fa402942715b1718ac7fcd5aa1b"
+  integrity sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==
   dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
+    "@typescript-eslint/types" "4.29.2"
+    "@typescript-eslint/visitor-keys" "4.29.2"
 
-"@typescript-eslint/types@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.1.tgz#94cce6cf7cc83451df03339cda99d326be2feaf5"
-  integrity sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==
+"@typescript-eslint/types@4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
+  integrity sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==
 
-"@typescript-eslint/typescript-estree@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz#7b32a25ff8e51f2671ccc6b26cdbee3b1e6c5e7f"
-  integrity sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==
+"@typescript-eslint/typescript-estree@4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz#a0ea8b98b274adbb2577100ba545ddf8bf7dc219"
+  integrity sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==
   dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
+    "@typescript-eslint/types" "4.29.2"
+    "@typescript-eslint/visitor-keys" "4.29.2"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz#0615be8b55721f5e854f3ee99f1a714f2d093e5d"
-  integrity sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==
+"@typescript-eslint/visitor-keys@4.29.2":
+  version "4.29.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz#d2da7341f3519486f50655159f4e5ecdcb2cd1df"
+  integrity sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==
   dependencies:
-    "@typescript-eslint/types" "4.29.1"
+    "@typescript-eslint/types" "4.29.2"
     eslint-visitor-keys "^2.0.0"
 
 JSONStream@^1.0.4:
@@ -1302,15 +1302,15 @@ browser-process-hrtime@^1.0.0:
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browserslist@^4.16.6:
-  version "4.16.7"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.7.tgz#108b0d1ef33c4af1b587c54f390e7041178e4335"
-  integrity sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==
+  version "4.16.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.8.tgz#cb868b0b554f137ba6e33de0ecff2eda403c4fb0"
+  integrity sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==
   dependencies:
-    caniuse-lite "^1.0.30001248"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.793"
+    caniuse-lite "^1.0.30001251"
+    colorette "^1.3.0"
+    electron-to-chromium "^1.3.811"
     escalade "^3.1.1"
-    node-releases "^1.1.73"
+    node-releases "^1.1.75"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -1326,7 +1326,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
@@ -1355,7 +1355,7 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001248:
+caniuse-lite@^1.0.30001251:
   version "1.0.30001251"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
   integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
@@ -1455,7 +1455,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.2:
+colorette@^1.2.2, colorette@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
@@ -1523,9 +1523,9 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
     safe-buffer "~5.1.1"
 
 cosmiconfig@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
-  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -1666,10 +1666,10 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-electron-to-chromium@^1.3.793:
-  version "1.3.806"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.806.tgz#21502100f11aead6c501d1cd7f2504f16c936642"
-  integrity sha512-AH/otJLAAecgyrYp0XK1DPiGVWcOgwPeJBOLeuFQ5l//vhQhwC9u6d+GijClqJAmsHG4XDue81ndSQPohUu0xA==
+electron-to-chromium@^1.3.811:
+  version "1.3.814"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz#418fad80c3276a46103ca72a21a8290620d83c4a"
+  integrity sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -1907,9 +1907,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastq@^1.6.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.1.tgz#5d8175aae17db61947f8b162cfc7f63264d22807"
-  integrity sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.12.0.tgz#ed7b6ab5d62393fb2cc591c853652a5c318bf794"
+  integrity sha512-VNX0QkHK3RsXVKr9KrlUv/FoTa0NdbYoHHl7uXHv2rzyHSlxjdNAKug2twd9luJxpcyNeAgf5iPPMutJO67Dfg==
   dependencies:
     reusify "^1.0.4"
 
@@ -2243,10 +2243,10 @@ is-ci@^3.0.0:
   dependencies:
     ci-info "^3.1.1"
 
-is-core-module@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
-  integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+is-core-module@^2.2.0, is-core-module@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
+  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
   dependencies:
     has "^1.0.3"
 
@@ -3125,11 +3125,6 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@1.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -3155,10 +3150,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.73:
-  version "1.1.74"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.74.tgz#e5866488080ebaa70a93b91144ccde06f3c3463e"
-  integrity sha512-caJBVempXZPepZoZAPCWRTNxYQ+xtG/KAi4ozTA5A+nJ7IU+kLQCbqaUjb5Rwy14M9upBWiQ4NutcmW04LJSRw==
+node-releases@^1.1.75:
+  version "1.1.75"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
+  integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -3171,12 +3166,12 @@ normalize-package-data@^2.5.0:
     validate-npm-package-license "^3.0.1"
 
 normalize-package-data@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.2.tgz#cae5c410ae2434f9a6c1baa65d5bc3b9366c8699"
-  integrity sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
+  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
   dependencies:
     hosted-git-info "^4.0.1"
-    resolve "^1.20.0"
+    is-core-module "^2.5.0"
     semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
@@ -3948,19 +3943,17 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-jest@^27.0.4:
-  version "27.0.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.4.tgz#df49683535831560ccb58f94c023d831b1b80df0"
-  integrity sha512-c4E1ECy9Xz2WGfTMyHbSaArlIva7Wi2p43QOMmCqjSSjHP06KXv+aT+eSY+yZMuqsMi3k7pyGsGj2q5oSl5WfQ==
+ts-jest@^27.0.5:
+  version "27.0.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.5.tgz#0b0604e2271167ec43c12a69770f0bb65ad1b750"
+  integrity sha512-lIJApzfTaSSbtlksfFNHkWOzLJuuSm4faFAfo5kvzOiRAuoN4/eKxVJ2zEAho8aecE04qX6K1pAzfH5QHL1/8w==
   dependencies:
     bs-logger "0.x"
-    buffer-from "1.x"
     fast-json-stable-stringify "2.x"
     jest-util "^27.0.0"
     json5 "2.x"
     lodash "4.x"
     make-error "1.x"
-    mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
 


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (891114421fecc92119224319a0231e829b5a34c5)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/use-unmount-ref/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>cli.js -u --packageFile package.json</em></summary>

```Shell
Using yarn
Upgrading /home/runner/work/use-unmount-ref/use-unmount-ref/package.json

 @technote-space/github-action-test-helper   ^0.7.22  →   ^0.7.24     
 @types/node                                 ^16.6.1  →   ^16.7.1     
 @types/react                               ^17.0.18  →  ^17.0.19     
 @typescript-eslint/eslint-plugin            ^4.29.1  →   ^4.29.2     
 @typescript-eslint/parser                   ^4.29.1  →   ^4.29.2     
 ts-jest                                     ^27.0.4  →   ^27.0.5     

Run yarn install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.11
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ [ -n "$CI" ] || [ ! -f node_modules/.bin/husky ] || husky install
Done in 20.85s.
```

### stderr:

```Shell
warning "@technote-space/github-action-test-helper > @octokit/plugin-rest-endpoint-methods@5.8.0" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.11
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 376 new dependencies.
info Direct dependencies
├─ @commitlint/cli@13.1.0
├─ @commitlint/config-conventional@13.1.0
├─ @technote-space/github-action-test-helper@0.7.24
├─ @testing-library/react-hooks@7.0.1
├─ @types/jest@27.0.1
├─ @types/react@17.0.19
├─ @typescript-eslint/eslint-plugin@4.29.2
├─ @typescript-eslint/parser@4.29.2
├─ eslint@7.32.0
├─ husky@7.0.1
├─ jest@27.0.6
├─ lint-staged@11.1.2
├─ pinst@2.1.6
├─ react-test-renderer@17.0.2
├─ react@17.0.2
├─ ts-jest@27.0.5
└─ typescript@4.3.5
info All dependencies
├─ @actions/core@1.5.0
├─ @actions/github@5.0.0
├─ @actions/http-client@1.0.11
├─ @babel/compat-data@7.15.0
├─ @babel/core@7.15.0
├─ @babel/helper-compilation-targets@7.15.0
├─ @babel/helper-function-name@7.14.5
├─ @babel/helper-get-function-arity@7.14.5
├─ @babel/helper-hoist-variables@7.14.5
├─ @babel/helper-member-expression-to-functions@7.15.0
├─ @babel/helper-module-imports@7.14.5
├─ @babel/helper-module-transforms@7.15.0
├─ @babel/helper-optimise-call-expression@7.14.5
├─ @babel/helper-replace-supers@7.15.0
├─ @babel/helper-simple-access@7.14.8
├─ @babel/helper-validator-option@7.14.5
├─ @babel/helpers@7.15.3
├─ @babel/highlight@7.14.5
├─ @babel/plugin-syntax-async-generators@7.8.4
├─ @babel/plugin-syntax-bigint@7.8.3
├─ @babel/plugin-syntax-class-properties@7.12.13
├─ @babel/plugin-syntax-import-meta@7.10.4
├─ @babel/plugin-syntax-json-strings@7.8.3
├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
├─ @babel/plugin-syntax-numeric-separator@7.10.4
├─ @babel/plugin-syntax-object-rest-spread@7.8.3
├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
├─ @babel/plugin-syntax-optional-chaining@7.8.3
├─ @babel/plugin-syntax-top-level-await@7.14.5
├─ @babel/plugin-syntax-typescript@7.14.5
├─ @babel/template@7.14.5
├─ @bcoe/v8-coverage@0.2.3
├─ @commitlint/cli@13.1.0
├─ @commitlint/config-conventional@13.1.0
├─ @commitlint/ensure@13.1.0
├─ @commitlint/execute-rule@13.0.0
├─ @commitlint/format@13.1.0
├─ @commitlint/is-ignored@13.1.0
├─ @commitlint/lint@13.1.0
├─ @commitlint/load@13.1.0
├─ @commitlint/message@13.0.0
├─ @commitlint/parse@13.1.0
├─ @commitlint/read@13.1.0
├─ @commitlint/resolve-extends@13.0.0
├─ @commitlint/rules@13.1.0
├─ @commitlint/to-lines@13.0.0
├─ @commitlint/top-level@13.0.0
├─ @eslint/eslintrc@0.4.3
├─ @humanwhocodes/config-array@0.5.0
├─ @humanwhocodes/object-schema@1.2.0
├─ @istanbuljs/load-nyc-config@1.1.0
├─ @jest/globals@27.0.6
├─ @jest/reporters@27.0.6
├─ @jest/test-sequencer@27.0.6
├─ @nodelib/fs.scandir@2.1.5
├─ @nodelib/fs.stat@2.0.5
├─ @nodelib/fs.walk@1.2.8
├─ @octokit/auth-token@2.4.5
├─ @octokit/core@3.5.1
├─ @octokit/endpoint@6.0.12
├─ @octokit/graphql@4.6.4
├─ @octokit/openapi-types@9.7.0
├─ @octokit/plugin-paginate-rest@2.15.1
├─ @octokit/plugin-rest-endpoint-methods@5.8.0
├─ @octokit/request-error@2.1.0
├─ @sinonjs/commons@1.8.3
├─ @sinonjs/fake-timers@7.1.2
├─ @technote-space/github-action-test-helper@0.7.24
├─ @testing-library/react-hooks@7.0.1
├─ @tootallnate/once@1.1.2
├─ @types/babel__core@7.1.15
├─ @types/babel__generator@7.6.3
├─ @types/babel__template@7.4.1
├─ @types/babel__traverse@7.14.2
├─ @types/graceful-fs@4.1.5
├─ @types/istanbul-lib-coverage@2.0.3
├─ @types/istanbul-lib-report@3.0.0
├─ @types/istanbul-reports@3.0.1
├─ @types/jest@27.0.1
├─ @types/json-schema@7.0.9
├─ @types/minimist@1.2.2
├─ @types/normalize-package-data@2.4.1
├─ @types/parse-json@4.0.0
├─ @types/prettier@2.3.2
├─ @types/prop-types@15.7.4
├─ @types/react-dom@17.0.9
├─ @types/react-test-renderer@17.0.1
├─ @types/react@17.0.19
├─ @types/scheduler@0.16.2
├─ @types/stack-utils@2.0.1
├─ @types/yargs-parser@20.2.1
├─ @typescript-eslint/eslint-plugin@4.29.2
├─ @typescript-eslint/experimental-utils@4.29.2
├─ @typescript-eslint/parser@4.29.2
├─ abab@2.0.5
├─ acorn-globals@6.0.0
├─ acorn-jsx@5.3.2
├─ acorn-walk@7.2.0
├─ acorn@7.4.1
├─ aggregate-error@3.1.0
├─ ajv@6.12.6
├─ ansi-colors@4.1.1
├─ ansi-escapes@4.3.2
├─ anymatch@3.1.2
├─ argparse@1.0.10
├─ array-ify@1.0.0
├─ array-union@2.1.0
├─ arrify@1.0.1
├─ asynckit@0.4.0
├─ babel-jest@27.0.6
├─ babel-plugin-jest-hoist@27.0.6
├─ babel-preset-jest@27.0.6
├─ balanced-match@1.0.2
├─ before-after-hook@2.2.2
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ browser-process-hrtime@1.0.0
├─ browserslist@4.16.8
├─ bs-logger@0.2.6
├─ bser@2.1.1
├─ buffer-from@1.1.2
├─ camelcase-keys@6.2.2
├─ caniuse-lite@1.0.30001251
├─ chalk@4.1.2
├─ char-regex@1.0.2
├─ ci-info@3.2.0
├─ cjs-module-lexer@1.2.2
├─ clean-stack@2.2.0
├─ cli-cursor@3.1.0
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ colorette@1.3.0
├─ combined-stream@1.0.8
├─ commander@7.2.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@5.0.12
├─ conventional-changelog-conventionalcommits@4.6.0
├─ conventional-commits-parser@3.2.1
├─ convert-source-map@1.8.0
├─ cross-spawn@7.0.3
├─ cssom@0.4.4
├─ cssstyle@2.3.0
├─ csstype@3.0.8
├─ dargs@7.0.0
├─ data-urls@2.0.0
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ decimal.js@10.3.1
├─ dedent@0.7.0
├─ deep-is@0.1.3
├─ deepmerge@4.2.2
├─ delayed-stream@1.0.0
├─ deprecation@2.3.1
├─ detect-newline@3.1.0
├─ diff-sequences@27.0.6
├─ dir-glob@3.0.1
├─ doctrine@3.0.0
├─ domexception@2.0.1
├─ dot-prop@5.3.0
├─ electron-to-chromium@1.3.814
├─ emoji-regex@8.0.0
├─ enquirer@2.3.6
├─ error-ex@1.3.2
├─ escape-string-regexp@4.0.0
├─ escodegen@2.0.0
├─ eslint-utils@2.1.0
├─ eslint@7.32.0
├─ espree@7.3.1
├─ esprima@4.0.1
├─ esquery@1.4.0
├─ esrecurse@4.3.0
├─ fast-glob@3.2.7
├─ fast-levenshtein@2.0.6
├─ fastq@1.12.0
├─ fb-watchman@2.0.1
├─ file-entry-cache@6.0.1
├─ fill-range@7.0.1
├─ flat-cache@3.0.4
├─ flatted@3.2.2
├─ form-data@3.0.1
├─ fromentries@1.3.2
├─ fs-extra@10.0.0
├─ fs.realpath@1.0.0
├─ function-bind@1.1.1
├─ gensync@1.0.0-beta.2
├─ get-own-enumerable-property-symbols@3.0.2
├─ get-package-type@0.1.0
├─ get-stream@6.0.1
├─ git-raw-commits@2.0.10
├─ glob@7.1.7
├─ global-dirs@0.1.1
├─ globals@13.11.0
├─ globby@11.0.4
├─ hard-rejection@2.1.0
├─ has@1.0.3
├─ hosted-git-info@4.0.2
├─ html-encoding-sniffer@2.0.1
├─ html-escaper@2.0.2
├─ http-proxy-agent@4.0.1
├─ https-proxy-agent@5.0.0
├─ human-signals@2.1.0
├─ husky@7.0.1
├─ iconv-lite@0.4.24
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.8
├─ is-arrayish@0.2.1
├─ is-core-module@2.6.0
├─ is-extglob@2.1.1
├─ is-glob@4.0.1
├─ is-number@7.0.0
├─ is-obj@1.0.1
├─ is-plain-obj@1.1.0
├─ is-potential-custom-element-name@1.0.1
├─ is-regexp@1.0.0
├─ is-stream@2.0.1
├─ is-text-path@1.0.1
├─ is-unicode-supported@0.1.0
├─ isexe@2.0.0
├─ istanbul-lib-instrument@4.0.3
├─ istanbul-lib-source-maps@4.0.0
├─ istanbul-reports@3.0.2
├─ jest-changed-files@27.0.6
├─ jest-cli@27.0.6
├─ jest-docblock@27.0.6
├─ jest-jasmine2@27.0.6
├─ jest-leak-detector@27.0.6
├─ jest-pnp-resolver@1.2.2
├─ jest-resolve-dependencies@27.0.6
├─ jest-serializer@27.0.6
├─ jest-util@27.0.6
├─ jest-watcher@27.0.6
├─ jest@27.0.6
├─ js-tokens@4.0.0
├─ jsdom@16.7.0
├─ jsesc@2.5.2
├─ json-parse-even-better-errors@2.3.1
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ json5@2.2.0
├─ jsonfile@6.1.0
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ kleur@3.0.3
├─ leven@3.1.0
├─ lines-and-columns@1.1.6
├─ lint-staged@11.1.2
├─ listr2@3.11.0
├─ locate-path@5.0.0
├─ lodash.clonedeep@4.5.0
├─ lodash.merge@4.6.2
├─ lodash.truncate@4.4.2
├─ lodash@4.17.21
├─ log-symbols@4.1.0
├─ log-update@4.0.0
├─ make-dir@3.1.0
├─ make-error@1.3.6
├─ makeerror@1.0.11
├─ map-obj@1.0.1
├─ mime-db@1.49.0
├─ mime-types@2.1.32
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.5
├─ ms@2.1.2
├─ node-fetch@2.6.1
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-releases@1.1.75
├─ normalize-package-data@3.0.3
├─ npm-run-path@4.0.1
├─ nwsapi@2.2.0
├─ onetime@5.1.2
├─ optionator@0.9.1
├─ p-each-series@2.2.0
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ parse5@6.0.1
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.7
├─ picomatch@2.3.0
├─ pinst@2.1.6
├─ pirates@4.0.1
├─ pkg-dir@4.2.0
├─ please-upgrade-node@3.2.0
├─ progress@2.0.3
├─ prompts@2.4.1
├─ psl@1.8.0
├─ queue-microtask@1.2.3
├─ quick-lru@4.0.1
├─ react-error-boundary@3.1.3
├─ react-is@17.0.2
├─ react-shallow-renderer@16.14.1
├─ react-test-renderer@17.0.2
├─ react@17.0.2
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ regenerator-runtime@0.13.9
├─ require-from-string@2.0.2
├─ resolve-cwd@3.0.0
├─ resolve-global@1.0.0
├─ resolve@1.20.0
├─ restore-cursor@3.1.0
├─ reusify@1.0.4
├─ rimraf@3.0.2
├─ run-parallel@1.2.0
├─ rxjs@6.6.7
├─ safe-buffer@5.1.2
├─ safer-buffer@2.1.2
├─ saxes@5.0.1
├─ scheduler@0.20.2
├─ semver-compare@1.0.0
├─ semver@7.3.5
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ sisteransi@1.0.5
├─ source-map-support@0.5.19
├─ source-map@0.6.1
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ sprintf-js@1.0.3
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ stringify-object@3.3.0
├─ strip-bom@4.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.1
├─ supports-color@7.2.0
├─ supports-hyperlinks@2.2.0
├─ symbol-tree@3.2.4
├─ table@6.7.1
├─ terminal-link@2.1.1
├─ test-exclude@6.0.0
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmpl@1.0.4
├─ to-fast-properties@2.0.0
├─ to-regex-range@5.0.1
├─ tough-cookie@4.0.0
├─ tr46@2.1.0
├─ trim-newlines@3.0.1
├─ trim-off-newlines@1.0.1
├─ ts-jest@27.0.5
├─ tslib@1.14.1
├─ tunnel@0.0.6
├─ type-detect@4.0.8
├─ type-fest@0.20.2
├─ typedarray-to-buffer@3.1.5
├─ typescript@4.3.5
├─ util-deprecate@1.0.2
├─ v8-compile-cache@2.3.0
├─ v8-to-istanbul@8.0.0
├─ w3c-hr-time@1.0.2
├─ w3c-xmlserializer@2.0.0
├─ walker@1.0.7
├─ whatwg-url@8.7.0
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ write-file-atomic@3.0.3
├─ ws@7.5.3
├─ xmlchars@2.2.0
├─ yallist@4.0.0
├─ yaml@1.10.2
├─ yargs-parser@20.2.9
└─ yocto-queue@0.1.0
Done in 9.48s.
```

### stderr:

```Shell
warning "@technote-space/github-action-test-helper > @octokit/plugin-rest-endpoint-methods@5.8.0" has unmet peer dependency "@octokit/core@>=3".
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.11
0 vulnerabilities found - Packages audited: 576
Done in 1.04s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)